### PR TITLE
feat(ama-bot): ama slash commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,17 +1,18 @@
 {
-	"permissions": {
-		"allow": [
-			"Bash(npm view *)",
-			"Bash(yarn install *)",
-			"Bash(yarn workspace *)",
-			"Bash(yarn turbo *)",
-			"Bash(yarn prettier *)",
-			"Bash(yarn lint *)",
-			"Bash(gh issue view *)",
-			"Bash(gh issue list *)",
-			"Bash(gh pr view *)",
-			"Bash(gh pr list *)",
-			"Bash(git mv *)"
-		]
-	}
+  "permissions": {
+    "allow": [
+      "Bash(npm view *)",
+      "Bash(yarn install *)",
+      "Bash(yarn workspace *)",
+      "Bash(yarn turbo *)",
+      "Bash(yarn prettier *)",
+      "Bash(yarn lint *)",
+      "Bash(gh issue view *)",
+      "Bash(gh issue list *)",
+      "Bash(gh pr view *)",
+      "Bash(gh pr list *)",
+      "Bash(git mv *)",
+      "Bash(echo \"EXIT: $?\")"
+    ]
+  }
 }

--- a/docs/roadmap/00-overview.md
+++ b/docs/roadmap/00-overview.md
@@ -57,9 +57,9 @@ M0 also included creating GitHub milestones, labels, and seed issues for this ro
 | Milestone                      | Doc                                                | Target (from 2026-07-16, ~7 hrs/wk) | Status            |
 | ------------------------------ | -------------------------------------------------- | ----------------------------------- | ----------------- |
 | M0 — Scaffolding & discovery   | this doc set + GitHub setup                        | ~2026-07-23                         | Done (2026-07-16) |
-| M1 — Foundation refactor       | [02-foundation.md](02-foundation.md)               | ~2026-08-20                         | Code complete (2026-07-17); pending interactive Discord OAuth click-through verification and closing #132 |
-| M2 — Dashboard-config solid    | [03-dashboard-config.md](03-dashboard-config.md)   | ~2026-09-17                         | Not started       |
-| M3 — AMA fully running         | [04-ama-complete.md](04-ama-complete.md)           | ~2026-11-05                         | Not started       |
+| M1 — Foundation refactor       | [02-foundation.md](02-foundation.md)               | ~2026-08-20                         | Done (2026-07-17), milestone closed |
+| M2 — Dashboard-config solid    | [03-dashboard-config.md](03-dashboard-config.md)   | ~2026-09-17                         | Done (2026-07-18), milestone closed |
+| M3 — AMA fully running         | [04-ama-complete.md](04-ama-complete.md)           | ~2026-11-05                         | In progress — Cluster 1 (question pipeline) done; Cluster 2 (slash-command infra) done, command set in progress (#143); Clusters 3–4 not started |
 | M4 — AMA drain-and-swap (live) | [05-migration-cutover.md](05-migration-cutover.md) | ~2026-11-19                         | Not started       |
 | M5 — ModMail port + migrate    | [06-modmail-port.md](06-modmail-port.md)           | ~2027-01-mid                        | Not started       |
 

--- a/docs/roadmap/04-ama-complete.md
+++ b/docs/roadmap/04-ama-complete.md
@@ -29,7 +29,7 @@ The mod→guest→answers state machine exists; what's incomplete:
 
 - [x] **Guest-review queue** (#139) — `guestApprove.ts`/`guestSkip.ts` exist and mirror `modApprove.ts`/`modDeny.ts`: question submitted → mod-approved → lands in guest queue → guest-approved → answers channel, with the same atomic-claim/lost-race cleanup pattern.
 - [x] **Flagged/reported queue** — a "flag" action from the mod queue (`mod-flag` component) posts into the flagged channel and moves the question to a terminal `FLAGGED` state. Unlike the mod/guest queues, nothing routes back out of it via the bot: it's a read-only surface for mods to review reported content and act on the user directly through Discord's own moderation tools, not a pipeline stage.
-- [x] **End/close-AMA flow** (#141) — `updateAMA`'s `ended` branch flips the flag from the dashboard; `submitQuestion.ts` rejects new submissions once `ama.ended`, and `guestApprove`/`modApprove` etc. reject further action on an ended session. Reflected in the dashboard list via M2's `IncludeEndedToggle`/`AMASessionCard`. **Still open:** a bot-side `/ama end` command — decided (see Cluster 2) and tracked under #143, not yet implemented.
+- [x] **End/close-AMA flow** (#141) — `updateAMA`'s `ended` branch flips the flag from the dashboard; `submitQuestion.ts` rejects new submissions once `ama.ended`, and `guestApprove`/`modApprove` etc. reject further action on an ended session. Reflected in the dashboard list via M2's `IncludeEndedToggle`/`AMASessionCard`. The bot-side `/ama end` command is implemented too, see Cluster 2.
 
 ## Cluster 2 — In-Discord slash commands
 

--- a/docs/roadmap/04-ama-complete.md
+++ b/docs/roadmap/04-ama-complete.md
@@ -18,37 +18,44 @@ A gateway bot (`@discordjs/ws` WebSocketManager + `@discordjs/core` Client, Guil
   - `postToModQueue` / `postToGuestQueue` / `postToFlaggedQueue` / `postToAnswersChannel` — builder functions constructing Components V2 (`ContainerBuilder`) messages (text + avatar thumbnail + media gallery for attachments) with the right Approve/Deny/Flag/Skip buttons per queue.
 - `components/submitQuestion.ts` — user clicks "Submit a question" on the prompt message → opens a modal (text + optional uploads, gated by `allowedQuestionUploads`) → collects modal → inserts `AMAQuestion` → routes into mod/guest/answers per which queues are configured.
 - `components/modApprove.ts` / `modDeny.ts` — parse question ID from `custom_id`, advance/deny via `getNextQueue`, disable buttons on the source message.
-- `lib/resolvers/*` — custom discord.js-style option resolvers (`ChatInputInteractionOptionResolver`, `ModalInteractionOptionResolver`, `ContextMenuInteractionOptionResolver`, `AutocompleteInteractionOptionResolver`) — **built but not yet wired to any slash command handling.** There is currently no `ApplicationCommand` interaction routing in `index.ts`/gateway handling.
+- `components/guestApprove.ts` / `guestSkip.ts` — guest-side mirror of the mod handlers (#139): resolve the question, post to the answers channel, atomically claim the row (`WHERE state = 'PENDING_GUEST_REVIEW'`), clean up a lost claim race, reject if the session has ended.
+- `lib/commands.ts` — command-handler loader mirroring `lib/components.ts` (glob `commands/**/*.js`, register `{ name, data, handle, handleAutocomplete? }`); `index.ts` routes `ApplicationCommand` and `ApplicationCommandAutocomplete` interactions to it. Built in #142 (PR #191).
+- `commands/deploy.ts` — the only command implemented so far: admin-gated (`env.ADMINS`), bulk-overwrites **global** commands (`bulkOverwriteGlobalCommands`) from every registered handler's `data`. The scope question Cluster 2 originally left open ("guild-scoped is simpler to iterate on") was decided in favor of **global-only** — there is no per-guild registration path, so any new command handler's `data` is picked up automatically by the next `/deploy` run.
+- Option parsing no longer uses a hand-rolled resolver — `lib/resolvers/*` was deleted in #142/PR #191 and replaced with `@sapphire/discord-utilities`'s `ChatInputInteractionOptionResolver` / `ModalInteractionOptionResolver` / `ContextMenuInteractionOptionResolver` / `AutocompleteInteractionOptionResolver` (equivalent API, external dependency instead of in-repo code). `components/submitQuestion.ts` already uses `ModalInteractionOptionResolver` from that package as the reference example.
 
 ## Cluster 1 — Full question pipeline
 
 The mod→guest→answers state machine exists; what's incomplete:
 
-- [ ] **Guest-review queue** — confirm `postToGuestQueue` + its approve/deny component handlers are fully implemented and tested end-to-end (question submitted → mod-approved → lands in guest queue → guest-approved → answers channel). If guest-side component handlers (`guestApprove`/`guestDeny`) don't exist yet, add them mirroring `modApprove.ts`/`modDeny.ts`.
+- [x] **Guest-review queue** (#139) — `guestApprove.ts`/`guestSkip.ts` exist and mirror `modApprove.ts`/`modDeny.ts`: question submitted → mod-approved → lands in guest queue → guest-approved → answers channel, with the same atomic-claim/lost-race cleanup pattern.
 - [x] **Flagged/reported queue** — a "flag" action from the mod queue (`mod-flag` component) posts into the flagged channel and moves the question to a terminal `FLAGGED` state. Unlike the mod/guest queues, nothing routes back out of it via the bot: it's a read-only surface for mods to review reported content and act on the user directly through Discord's own moderation tools, not a pipeline stage.
-- [ ] **End/close-AMA flow** — `AMASession.ended` exists in the schema but nothing flips it from the bot side yet (only via the API's `updateAMA` route, if at all). Add: a way to end an AMA (dashboard action calling `updateAMA` is likely sufficient — decide whether a bot-side command is also needed, see Cluster 2) that stops accepting new submissions (the "Submit a question" button should reject/disable once `ended`) and is reflected in the dashboard list ([03-dashboard-config.md](03-dashboard-config.md)'s `IncludeEndedToggle`/`AMASessionCard`).
+- [x] **End/close-AMA flow** (#141) — `updateAMA`'s `ended` branch flips the flag from the dashboard; `submitQuestion.ts` rejects new submissions once `ama.ended`, and `guestApprove`/`modApprove` etc. reject further action on an ended session. Reflected in the dashboard list via M2's `IncludeEndedToggle`/`AMASessionCard`. **Still open:** a bot-side `/ama end` command — decided (see Cluster 2) and tracked under #143, not yet implemented.
 
 ## Cluster 2 — In-Discord slash commands
 
-Resolvers exist; the command layer doesn't. Build:
+Command-handler infra is done (#142, PR #191): `lib/commands.ts` mirrors `lib/components.ts`'s loader, `index.ts` routes `ApplicationCommand`/`ApplicationCommandAutocomplete` interactions to it, and registration is a **global** bulk overwrite via the admin-only `/deploy` command (see "Current state" above). What's left is the actual `/ama` command set — this is #143's remaining scope. Use `@sapphire/discord-utilities`'s `ChatInputInteractionOptionResolver`/`ModalInteractionOptionResolver` for option parsing (the in-repo resolvers this doc used to point to were deleted in favor of that package).
 
-- [ ] A command-handler loader mirroring `lib/components.ts` (glob `commands/**/*.js`, register `{ name, data, handle() }`).
-- [ ] Wire `InteractionCreate` to route `ApplicationCommand` (and `ApplicationCommandAutocomplete`) interactions to it, alongside the existing `MessageComponent` routing.
-- [ ] Command registration (bulk overwrite guild or global commands on boot — decide scope; guild-scoped is simpler to iterate on during development).
-- [ ] Minimum command set for "fully running": `/ama create`, `/ama end`, `/ama repost-prompt`, `/ama stats` (ties into Cluster 4). Use the existing `ChatInputInteractionOptionResolver`/`ModalInteractionOptionResolver` for option parsing — they were built for exactly this and are currently unused.
+Owner decisions for the four subcommands (given without re-reading this doc first, so treat as authoritative over the original one-liners below):
 
-## Cluster 3 — Answer-publishing polish
+- [x] **`/ama create`** — deliberately **not** a creation flow. Implemented as `commands/ama.ts`'s `create` subcommand: an ephemeral reply linking to the dashboard's AMA-create screen (`${FRONTEND_URL}/dashboard/:guildId/ama/amas/new`), nothing more. **Unverified end-to-end** — build+lint are green but this hasn't been click-tested against a live guild yet (see Verification).
+  - **Deferred idea (not M3 scope):** a future version could reply with a link carrying a scoped JWT that asserts "this Discord user ID has some privilege level on this guild" — both facts already proven by the user having been able to run the slash command in that guild. This would need (a) a new, more granular grant model on the frontend (e.g. "can start an AMA" rather than full server-admin/full-dashboard-grant), (b) a new token type and verification path, and (c) UI to consume it. Complex enough to warrant its own milestone-sized slice later (M4+/backlog) — do not attempt it as part of #143.
+- [x] **`/ama end`** — implemented: `commands/ama.ts`'s `end` subcommand replies with an ephemeral string-select listing the guild's ongoing (`ended = false`) sessions (max 25, Discord's select cap — fine for now, revisit pagination if a guild ever runs more concurrent AMAs than that); `components/amaEndSelect.ts` handles the selection, flips `ended` the same way `updateAMA`'s `ended` branch does (direct DB write, no HTTP call to `services/api`). **Unverified end-to-end**, see Verification.
+- [x] **`/ama repost-prompt`** — implemented: same select-menu UX (`components/amaRepostSelect.ts`), reusing `repostPrompt.ts`'s exact guard/replay/concurrency-safe-update logic but re-implemented against the bot's own `@discordjs/core` REST client (`getContext().service.client.api`) instead of the API's `discordAPIAma` (`@discordjs/rest`-based) client — the two clients aren't interchangeable, so this is a deliberate duplication, not an oversight; flagged inline in both files if either changes independently. **Unverified end-to-end**, see Verification.
+- [ ] **`/ama stats`** — **excluded from #143's scope**, not implemented. Cluster 4 (the stats/analytics data model and API surface) hasn't started (#146, #147 still open); a `/ama stats` command would either duplicate query logic that Cluster 4 is about to build properly or ship a throwaway version. Revisit once #146 lands.
+
+## Cluster 3 — Answer-publishing polish (#144, #145)
 
 - [ ] Confirm `postToAnswersChannel`'s Components V2 formatting is final-quality (avatar, question text, any attachments via media gallery) — this is the host-facing/public-facing output, worth extra polish pass.
-- [ ] **Repost prompt** — `repostPrompt` API route + `useRepostPrompt` hook exist; confirm the bot-side re-posts using the stored `AMAPromptData.promptJSONData` faithfully (raw vs. normal prompt mode, per `createAMA`'s `withRawPrompt`/`withRegularPrompt` schemas).
+- [ ] **Repost prompt** — the API-side route (`repostPrompt.ts`) and `useRepostPrompt` hook exist and are confirmed working from the dashboard; the bot-side `/ama repost-prompt` command (Cluster 2) is the remaining piece — confirm it re-posts using the stored `AmaPromptData.promptJsonData` faithfully (raw vs. normal prompt mode, per `createAMA`'s `prompt_raw`/`prompt` schemas).
 - [ ] **Edit/repost of published answers** — decide and implement: can a mod edit an already-answered question's published message (e.g. to fix a typo, or re-flag after the fact)? If yes, needs a component/command + a DB update path; if explicitly not supported this stage, document that decision here.
 
-## Cluster 4 — Analytics & export
+## Cluster 4 — Analytics & export (#146, #147)
 
 - [ ] **Per-AMA question-count stats** — `getAMAs` already returns `questionCount`; extend with a breakdown by `AMAQuestionState` (pending/flagged/approved/denied) for a real stats view.
 - [ ] **Stats API route(s)** — new `defineRoute`-based endpoint(s) (per [02-foundation.md](02-foundation.md)'s pattern) surfacing per-AMA and possibly per-guild aggregate stats.
 - [ ] **Dashboard stats view** — slot reserved in `AMADetails.tsx` per [03-dashboard-config.md](03-dashboard-config.md); build the actual charts/numbers here.
 - [ ] **CSV export route** — a `defineRoute` endpoint returning a CSV (or a signed download) of all questions for an AMA (author, content, state, timestamps) — for moderators wanting an offline record.
+- Not started; `/ama stats` (Cluster 2) is intentionally deferred until this lands, per owner decision.
 
 ## Verification
 

--- a/services/ama-bot/src/commands/ama.ts
+++ b/services/ama-bot/src/commands/ama.ts
@@ -1,0 +1,132 @@
+import { getContext } from '@chatsift/backend-core';
+import type { AmaSessions } from '@chatsift/db';
+import { ChatInputCommandBuilder } from '@discordjs/builders';
+import type { APIApplicationCommandInteraction, APIChatInputApplicationCommandInteraction } from '@discordjs/core';
+import { ApplicationIntegrationType, ComponentType, InteractionContextType, MessageFlags, PermissionFlagsBits } from '@discordjs/core';
+import { ChatInputInteractionOptionResolver } from '@sapphire/discord-utilities';
+import type { CommandHandler } from '../lib/commands.js';
+
+type SelectKind = 'end' | 'repost-prompt';
+
+const SELECT_CUSTOM_ID: Record<SelectKind, string> = {
+	end: 'ama-end-select',
+	'repost-prompt': 'ama-repost-select',
+};
+
+const SELECT_PLACEHOLDER: Record<SelectKind, string> = {
+	end: 'Select an AMA to end',
+	'repost-prompt': 'Select an AMA to repost the prompt for',
+};
+
+const SELECT_PROMPT: Record<SelectKind, string> = {
+	end: 'Choose which AMA to end:',
+	'repost-prompt': 'Choose which AMA to repost the prompt for:',
+};
+
+export default class AmaCommand implements CommandHandler {
+	public readonly name = 'ama';
+
+	public readonly data = new ChatInputCommandBuilder()
+		.setName('ama')
+		.setDescription('Manage Ask-Me-Anything sessions in this server')
+		.setContexts(InteractionContextType.Guild)
+		.setIntegrationTypes(ApplicationIntegrationType.GuildInstall)
+		.setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
+		.addSubcommands(
+			(subcommand) => subcommand.setName('create').setDescription('Get a link to create a new AMA from the dashboard'),
+			(subcommand) => subcommand.setName('end').setDescription('End one of this server’s ongoing AMAs'),
+			(subcommand) =>
+				subcommand.setName('repost-prompt').setDescription('Repost an AMA prompt message that was deleted'),
+		)
+		.toJSON();
+
+	public async handle(interaction: APIApplicationCommandInteraction) {
+		if (!interaction.guild_id) {
+			await getContext().service.client.api.interactions.reply(interaction.id, interaction.token, {
+				content: 'This command can only be used in a server.',
+				flags: MessageFlags.Ephemeral,
+			});
+			return;
+		}
+
+		const options = new ChatInputInteractionOptionResolver(interaction as APIChatInputApplicationCommandInteraction);
+		const subcommand = options.getSubcommand(true);
+
+		switch (subcommand) {
+			case 'create': {
+				await this.handleCreate(interaction);
+				break;
+			}
+
+			case 'end': {
+				await this.handleSelect(interaction, 'end');
+				break;
+			}
+
+			case 'repost-prompt': {
+				await this.handleSelect(interaction, 'repost-prompt');
+				break;
+			}
+
+			default: {
+				await getContext().service.client.api.interactions.reply(interaction.id, interaction.token, {
+					content: 'Unknown subcommand.',
+					flags: MessageFlags.Ephemeral,
+				});
+			}
+		}
+	}
+
+	/**
+	 * Deliberately does not create an AMA itself - creation needs the full config form (channels, upload limits,
+	 * prompt mode) that only the dashboard exposes. This just points at it.
+	 */
+	private async handleCreate(interaction: APIApplicationCommandInteraction) {
+		const url = `${getContext().FRONTEND_URL}/dashboard/${interaction.guild_id}/ama/amas/new`;
+
+		await getContext().service.client.api.interactions.reply(interaction.id, interaction.token, {
+			content: `Head to the dashboard to create a new AMA: ${url}`,
+			flags: MessageFlags.Ephemeral,
+		});
+	}
+
+	/**
+	 * Shared by `end` and `repost-prompt`: both act on one of the guild's ongoing AMAs, picked via a select menu
+	 * instead of a raw ID option. The actual action runs from the resulting `ama-end-select`/`ama-repost-select`
+	 * component handler once the user picks an option.
+	 */
+	private async handleSelect(interaction: APIApplicationCommandInteraction, kind: SelectKind) {
+		const sessions = await getContext().db<AmaSessions[]>`
+			SELECT * FROM ama_sessions WHERE guild_id = ${interaction.guild_id!} AND ended = false ORDER BY id DESC LIMIT 25
+		`;
+
+		if (!sessions.length) {
+			await getContext().service.client.api.interactions.reply(interaction.id, interaction.token, {
+				content: 'There are no ongoing AMAs in this server.',
+				flags: MessageFlags.Ephemeral,
+			});
+			return;
+		}
+
+		await getContext().service.client.api.interactions.reply(interaction.id, interaction.token, {
+			content: SELECT_PROMPT[kind],
+			flags: MessageFlags.Ephemeral,
+			components: [
+				{
+					type: ComponentType.ActionRow,
+					components: [
+						{
+							type: ComponentType.StringSelect,
+							custom_id: SELECT_CUSTOM_ID[kind],
+							placeholder: SELECT_PLACEHOLDER[kind],
+							options: sessions.map((session) => ({
+								label: session.title.slice(0, 100),
+								value: String(session.id),
+							})),
+						},
+					],
+				},
+			],
+		});
+	}
+}

--- a/services/ama-bot/src/components/amaEndSelect.ts
+++ b/services/ama-bot/src/components/amaEndSelect.ts
@@ -1,0 +1,46 @@
+import { getContext } from '@chatsift/backend-core';
+import type { AmaSessions } from '@chatsift/db';
+import type { APIMessageComponentInteraction, APIMessageStringSelectInteractionData } from '@discordjs/core';
+import type { ComponentHandler } from '../lib/components.js';
+
+export default class AmaEndSelectComponent implements ComponentHandler {
+	public readonly name = 'ama-end-select';
+
+	public readonly stateStore = null;
+
+	public async handle(interaction: APIMessageComponentInteraction) {
+		const [rawId] = (interaction.data as APIMessageStringSelectInteractionData).values;
+		const amaId = Number.parseInt(rawId!, 10);
+
+		await getContext().service.client.api.interactions.deferMessageUpdate(interaction.id, interaction.token);
+
+		const [session] = await getContext().db<AmaSessions[]>`
+			SELECT * FROM ama_sessions WHERE id = ${amaId}
+		`;
+
+		if (!session || session.guildId !== interaction.guild_id) {
+			await getContext().service.client.api.interactions.editReply(interaction.application_id, interaction.token, {
+				content: 'That AMA could not be found.',
+				components: [],
+			});
+			return;
+		}
+
+		if (session.ended) {
+			await getContext().service.client.api.interactions.editReply(interaction.application_id, interaction.token, {
+				content: `**${session.title}** has already ended.`,
+				components: [],
+			});
+			return;
+		}
+
+		await getContext().db`
+			UPDATE ama_sessions SET ended = true WHERE id = ${session.id}
+		`;
+
+		await getContext().service.client.api.interactions.editReply(interaction.application_id, interaction.token, {
+			content: `Ended **${session.title}**. It will no longer accept new questions.`,
+			components: [],
+		});
+	}
+}

--- a/services/ama-bot/src/components/amaRepostSelect.ts
+++ b/services/ama-bot/src/components/amaRepostSelect.ts
@@ -5,7 +5,8 @@ import type {
 	APIMessageStringSelectInteractionData,
 	RESTPostAPIChannelMessageJSONBody,
 } from '@discordjs/core';
-import { ButtonStyle, ComponentType } from '@discordjs/core';
+import { ButtonStyle, ComponentType, RESTJSONErrorCodes } from '@discordjs/core';
+import { DiscordAPIError } from '@discordjs/rest';
 import type { ComponentHandler } from '../lib/components.js';
 
 export default class AmaRepostSelectComponent implements ComponentHandler {
@@ -19,90 +20,134 @@ export default class AmaRepostSelectComponent implements ComponentHandler {
 
 		await getContext().service.client.api.interactions.deferMessageUpdate(interaction.id, interaction.token);
 
-		const [session] = await getContext().db<AmaSessions[]>`
-			SELECT * FROM ama_sessions WHERE id = ${amaId}
-		`;
-
-		if (!session || session.guildId !== interaction.guild_id) {
-			await getContext().service.client.api.interactions.editReply(interaction.application_id, interaction.token, {
-				content: 'That AMA could not be found.',
-				components: [],
-			});
-			return;
-		}
-
-		const [promptData] = await getContext().db<AmaPromptData[]>`
-			SELECT * FROM ama_prompt_data WHERE ama_id = ${session.id}
-		`;
-
-		if (!promptData) {
-			getContext().logger.error({ amaId: session.id }, 'AMA session has no prompt data row');
-			await getContext().service.client.api.interactions.editReply(interaction.application_id, interaction.token, {
-				content: 'No prompt data is stored for that AMA. Please contact a developer.',
-				components: [],
-			});
-			return;
-		}
-
-		// Mirrors services/api/src/routes/ama/repostPrompt.ts's guard: only repost if the original prompt message
-		// is actually gone, so a mod can't end up with two live "Submit a question" buttons for the same AMA.
-		let messageExists = false;
 		try {
-			await getContext().service.client.api.channels.getMessage(session.promptChannelId, promptData.promptMessageId);
-			messageExists = true;
-		} catch {
-			messageExists = false;
-		}
+			const [session] = await getContext().db<AmaSessions[]>`
+				SELECT * FROM ama_sessions WHERE id = ${amaId}
+			`;
 
-		if (messageExists) {
+			if (!session || session.guildId !== interaction.guild_id) {
+				await getContext().service.client.api.interactions.editReply(interaction.application_id, interaction.token, {
+					content: 'That AMA could not be found.',
+					components: [],
+				});
+				return;
+			}
+
+			if (session.ended) {
+				await getContext().service.client.api.interactions.editReply(interaction.application_id, interaction.token, {
+					content: `**${session.title}** has already ended — its prompt won't be reposted.`,
+					components: [],
+				});
+				return;
+			}
+
+			const [promptData] = await getContext().db<AmaPromptData[]>`
+				SELECT * FROM ama_prompt_data WHERE ama_id = ${session.id}
+			`;
+
+			if (!promptData) {
+				getContext().logger.error({ amaId: session.id }, 'AMA session has no prompt data row');
+				await getContext().service.client.api.interactions.editReply(interaction.application_id, interaction.token, {
+					content: 'No prompt data is stored for that AMA. Please contact a developer.',
+					components: [],
+				});
+				return;
+			}
+
+			// Mirrors services/api/src/routes/ama/repostPrompt.ts's guard: only repost if the original prompt message
+			// is actually gone, so a mod can't end up with two live "Submit a question" buttons for the same AMA.
+			// Only treat "the message is actually gone" (404 / Unknown Message) as messageExists = false — anything
+			// else (missing permissions, rate limits, transport errors) is rethrown below so it surfaces as a real
+			// failure instead of silently proceeding to create a duplicate prompt.
+			let messageExists = false;
+			try {
+				await getContext().service.client.api.channels.getMessage(session.promptChannelId, promptData.promptMessageId);
+				messageExists = true;
+			} catch (error) {
+				const isUnknownMessage =
+					error instanceof DiscordAPIError &&
+					(error.status === 404 || error.code === RESTJSONErrorCodes.UnknownMessage);
+
+				if (!isUnknownMessage) {
+					throw error;
+				}
+
+				messageExists = false;
+			}
+
+			if (messageExists) {
+				await getContext().service.client.api.interactions.editReply(interaction.application_id, interaction.token, {
+					content: `The prompt message for **${session.title}** still exists — delete it first if you want to repost.`,
+					components: [],
+				});
+				return;
+			}
+
+			let messageBody: RESTPostAPIChannelMessageJSONBody;
+			try {
+				messageBody = JSON.parse(promptData.promptJsonData) as RESTPostAPIChannelMessageJSONBody;
+			} catch (error) {
+				getContext().logger.error({ err: error, amaId: session.id }, 'Failed to parse stored AMA prompt JSON data');
+				await getContext().service.client.api.interactions.editReply(interaction.application_id, interaction.token, {
+					content: `**${session.title}**'s stored prompt data is corrupted. Please contact a developer.`,
+					components: [],
+				});
+				return;
+			}
+
+			const newPromptMessage = await getContext().service.client.api.channels.createMessage(session.promptChannelId, {
+				...messageBody,
+				components: [
+					{
+						type: ComponentType.ActionRow,
+						components: [
+							{
+								type: ComponentType.Button,
+								style: ButtonStyle.Primary,
+								label: 'Submit a question',
+								custom_id: 'submit-question',
+							},
+						],
+					},
+				],
+			});
+
+			// Conditional on the prompt_message_id we actually read above — if a concurrent repost (e.g. from the
+			// dashboard's repost action) already changed it, this affects zero rows instead of silently overwriting it.
+			const updateResult = await getContext().db`
+				UPDATE ama_prompt_data
+				SET prompt_message_id = ${newPromptMessage.id}
+				WHERE ama_id = ${session.id} AND prompt_message_id = ${promptData.promptMessageId}
+			`;
+
+			if (updateResult.count === 0) {
+				try {
+					await getContext().service.client.api.channels.deleteMessage(session.promptChannelId, newPromptMessage.id);
+				} catch (error) {
+					// Best-effort: a stray message from a lost concurrent-repost race isn't worth failing over.
+					getContext().logger.debug(
+						{ error, channelId: session.promptChannelId, messageId: newPromptMessage.id },
+						'Failed to clean up orphaned reposted prompt message',
+					);
+				}
+
+				await getContext().service.client.api.interactions.editReply(interaction.application_id, interaction.token, {
+					content: `**${session.title}**'s prompt was already reposted elsewhere.`,
+					components: [],
+				});
+				return;
+			}
+
 			await getContext().service.client.api.interactions.editReply(interaction.application_id, interaction.token, {
-				content: `The prompt message for **${session.title}** still exists — delete it first if you want to repost.`,
+				content: `Reposted the prompt for **${session.title}**.`,
 				components: [],
 			});
-			return;
-		}
-
-		const messageBody = JSON.parse(promptData.promptJsonData) as RESTPostAPIChannelMessageJSONBody;
-
-		const newPromptMessage = await getContext().service.client.api.channels.createMessage(session.promptChannelId, {
-			...messageBody,
-			components: [
-				{
-					type: ComponentType.ActionRow,
-					components: [
-						{
-							type: ComponentType.Button,
-							style: ButtonStyle.Primary,
-							label: 'Submit a question',
-							custom_id: 'submit-question',
-						},
-					],
-				},
-			],
-		});
-
-		// Conditional on the prompt_message_id we actually read above — if a concurrent repost (e.g. from the
-		// dashboard's repost action) already changed it, this affects zero rows instead of silently overwriting it.
-		const updateResult = await getContext().db`
-			UPDATE ama_prompt_data
-			SET prompt_message_id = ${newPromptMessage.id}
-			WHERE ama_id = ${session.id} AND prompt_message_id = ${promptData.promptMessageId}
-		`;
-
-		if (updateResult.count === 0) {
-			// eslint-disable-next-line promise/prefer-await-to-then
-			void getContext().service.client.api.channels.deleteMessage(session.promptChannelId, newPromptMessage.id).catch(() => null);
-
+		} catch (error) {
+			getContext().logger.error({ error, amaId }, 'Failed to repost AMA prompt');
 			await getContext().service.client.api.interactions.editReply(interaction.application_id, interaction.token, {
-				content: `**${session.title}**'s prompt was already reposted elsewhere.`,
+				content: 'Failed to repost the prompt. Please try again.',
 				components: [],
 			});
-			return;
 		}
-
-		await getContext().service.client.api.interactions.editReply(interaction.application_id, interaction.token, {
-			content: `Reposted the prompt for **${session.title}**.`,
-			components: [],
-		});
 	}
 }

--- a/services/ama-bot/src/components/amaRepostSelect.ts
+++ b/services/ama-bot/src/components/amaRepostSelect.ts
@@ -1,0 +1,108 @@
+import { getContext } from '@chatsift/backend-core';
+import type { AmaPromptData, AmaSessions } from '@chatsift/db';
+import type {
+	APIMessageComponentInteraction,
+	APIMessageStringSelectInteractionData,
+	RESTPostAPIChannelMessageJSONBody,
+} from '@discordjs/core';
+import { ButtonStyle, ComponentType } from '@discordjs/core';
+import type { ComponentHandler } from '../lib/components.js';
+
+export default class AmaRepostSelectComponent implements ComponentHandler {
+	public readonly name = 'ama-repost-select';
+
+	public readonly stateStore = null;
+
+	public async handle(interaction: APIMessageComponentInteraction) {
+		const [rawId] = (interaction.data as APIMessageStringSelectInteractionData).values;
+		const amaId = Number.parseInt(rawId!, 10);
+
+		await getContext().service.client.api.interactions.deferMessageUpdate(interaction.id, interaction.token);
+
+		const [session] = await getContext().db<AmaSessions[]>`
+			SELECT * FROM ama_sessions WHERE id = ${amaId}
+		`;
+
+		if (!session || session.guildId !== interaction.guild_id) {
+			await getContext().service.client.api.interactions.editReply(interaction.application_id, interaction.token, {
+				content: 'That AMA could not be found.',
+				components: [],
+			});
+			return;
+		}
+
+		const [promptData] = await getContext().db<AmaPromptData[]>`
+			SELECT * FROM ama_prompt_data WHERE ama_id = ${session.id}
+		`;
+
+		if (!promptData) {
+			getContext().logger.error({ amaId: session.id }, 'AMA session has no prompt data row');
+			await getContext().service.client.api.interactions.editReply(interaction.application_id, interaction.token, {
+				content: 'No prompt data is stored for that AMA. Please contact a developer.',
+				components: [],
+			});
+			return;
+		}
+
+		// Mirrors services/api/src/routes/ama/repostPrompt.ts's guard: only repost if the original prompt message
+		// is actually gone, so a mod can't end up with two live "Submit a question" buttons for the same AMA.
+		let messageExists = false;
+		try {
+			await getContext().service.client.api.channels.getMessage(session.promptChannelId, promptData.promptMessageId);
+			messageExists = true;
+		} catch {
+			messageExists = false;
+		}
+
+		if (messageExists) {
+			await getContext().service.client.api.interactions.editReply(interaction.application_id, interaction.token, {
+				content: `The prompt message for **${session.title}** still exists — delete it first if you want to repost.`,
+				components: [],
+			});
+			return;
+		}
+
+		const messageBody = JSON.parse(promptData.promptJsonData) as RESTPostAPIChannelMessageJSONBody;
+
+		const newPromptMessage = await getContext().service.client.api.channels.createMessage(session.promptChannelId, {
+			...messageBody,
+			components: [
+				{
+					type: ComponentType.ActionRow,
+					components: [
+						{
+							type: ComponentType.Button,
+							style: ButtonStyle.Primary,
+							label: 'Submit a question',
+							custom_id: 'submit-question',
+						},
+					],
+				},
+			],
+		});
+
+		// Conditional on the prompt_message_id we actually read above — if a concurrent repost (e.g. from the
+		// dashboard's repost action) already changed it, this affects zero rows instead of silently overwriting it.
+		const updateResult = await getContext().db`
+			UPDATE ama_prompt_data
+			SET prompt_message_id = ${newPromptMessage.id}
+			WHERE ama_id = ${session.id} AND prompt_message_id = ${promptData.promptMessageId}
+		`;
+
+		if (updateResult.count === 0) {
+			// eslint-disable-next-line promise/prefer-await-to-then
+			void getContext().service.client.api.channels.deleteMessage(session.promptChannelId, newPromptMessage.id).catch(() => null);
+
+			await getContext().service.client.api.interactions.editReply(interaction.application_id, interaction.token, {
+				content: `**${session.title}**'s prompt was already reposted elsewhere.`,
+				components: [],
+			});
+			return;
+		}
+
+		await getContext().service.client.api.interactions.editReply(interaction.application_id, interaction.token, {
+			content: `Reposted the prompt for **${session.title}**.`,
+			components: [],
+		});
+	}
+}


### PR DESCRIPTION
Closes #143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `/ama` command with `create`, `end`, and `repost-prompt` subcommands, including an active-session picker.
  * Added interactive select flows to end an AMA session and to repost a stored prompt with conflict-safe behavior.
  * Repost prompts now include a new **“Submit a question”** button and support guest-side approval/skip handling for posting answers.
* **Documentation**
  * Updated the roadmap to mark M1/M2 as completed and reflect M3 “AMA fully running spec” progress and remaining analytics/export work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->